### PR TITLE
[Style/#24] - 로그인 UI 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,15 @@
       "name": "13th-startpoint-web",
       "version": "0.0.0",
       "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^7.0.0",
+        "@fortawesome/free-regular-svg-icons": "^7.0.0",
+        "@fortawesome/free-solid-svg-icons": "^7.0.0",
+        "@fortawesome/react-fontawesome": "^0.2.3",
         "@tailwindcss/vite": "^4.1.11",
         "axios": "^1.11.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-icons": "^5.5.0",
         "react-minimal-pie-chart": "^9.1.1",
         "react-router-dom": "^7.8.1",
         "react-scroll": "^1.9.3",
@@ -892,6 +897,64 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.0.0.tgz",
+      "integrity": "sha512-PGMrIYXLGA5K8RWy8zwBkd4vFi4z7ubxtet6Yn13Plf6krRTwPbdlCwlcfmoX0R7B4Z643QvrtHmdQ5fNtfFCg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.0.0.tgz",
+      "integrity": "sha512-obBEF+zd98r/KtKVW6A+8UGWeaOoyMpl6Q9P3FzHsOnsg742aXsl8v+H/zp09qSSu/a/Hxe9LNKzbBaQq1CEbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "7.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-regular-svg-icons": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-7.0.0.tgz",
+      "integrity": "sha512-qAh0mTaCY22sQzMK2lKBrtn/aR4keUu5XmtdYR7d702laMe0h+Ab4Kj2pExR9HZkKhjKoq8pbwt8Td+mjW/ipQ==",
+      "license": "(CC-BY-4.0 AND MIT)",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "7.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-7.0.0.tgz",
+      "integrity": "sha512-njSLAllkOddYDCXgTFboXn54Oe5FcvpkWq+FoetOHR64PbN0608kM02Lze0xtISGpXgP+i26VyXRQA0Irh3Obw==",
+      "license": "(CC-BY-4.0 AND MIT)",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "7.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.3.tgz",
+      "integrity": "sha512-HlJco8RDY8NrzFVjy23b/7mNS4g9NegcrBG3n7jinwpc2x/AmSVk53IhWniLYM4szYLxRAFTAGwGn0EIlclDeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6 || ~7",
+        "react": "^16.3 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -3328,6 +3391,15 @@
       },
       "peerDependencies": {
         "react": "^19.1.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -10,10 +10,15 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^7.0.0",
+    "@fortawesome/free-regular-svg-icons": "^7.0.0",
+    "@fortawesome/free-solid-svg-icons": "^7.0.0",
+    "@fortawesome/react-fontawesome": "^0.2.3",
     "@tailwindcss/vite": "^4.1.11",
     "axios": "^1.11.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-icons": "^5.5.0",
     "react-minimal-pie-chart": "^9.1.1",
     "react-router-dom": "^7.8.1",
     "react-scroll": "^1.9.3",

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,30 +1,93 @@
-import React from "react";
+import React, { useState } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  faUser,
+  faKey,
+  faCircleExclamation,
+} from "@fortawesome/free-solid-svg-icons";
+import { useNavigate } from "react-router-dom";
 
 const Login = () => {
-  return (
-    <div className="flex items-center justify-center min-h-screen bg-gray-100">
-      <div className="bg-white p-8 rounded-2xl shadow-lg w-1/3">
-        <h2 className="text-4xl font-bold text-center text-blue-800">Login</h2>
+  const [userId, setUserId] = useState("");
+  const [password, setPassword] = useState("");
+  const [errorMessage, setErrorMessage] = useState("");
+  const navigate = useNavigate();
 
-        <div className="p-3 text-center">
-          Log in to your account and see all the details.
+  // 입력값 아무거나 넣어놔서 변경해야함
+  const handleLogin = () => {
+    if (userId !== "testuser" || password !== "1234") {
+      setErrorMessage("회원정보가 존재하지 않습니다. 다시 입력해주세요.");
+    } else {
+      setErrorMessage("");
+      navigate("/");
+    }
+  };
+
+  const handleUserIdChange = (e) => {
+    setUserId(e.target.value);
+    if (errorMessage) setErrorMessage("");
+  };
+
+  const handlePasswordChange = (e) => {
+    setPassword(e.target.value);
+    if (errorMessage) setErrorMessage("");
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <div className="p-5 rounded-2xl w-1/2">
+        <h2 className="text-[48px] font-bold text-center text-[#2E47A4]">
+          Login
+        </h2>
+
+        <div className="text-[20px] font-medium p-3 text-center mb-10">
+          계정에 로그인하면 모든 정보를 볼 수 있습니다.
         </div>
 
-        <input
-          type="text"
-          placeholder="Enter your ID"
-          className="w-full px-3 py-2 mb-4 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-800"
-        />
+        <div className="flex flex-col items-center justify-center gap-4">
+          <div className="relative w-[500px]">
+            <FontAwesomeIcon
+              icon={faUser}
+              className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500 p-2.5"
+            />
+            <input
+              type="text"
+              value={userId}
+              onChange={handleUserIdChange}
+              placeholder="아이디를 입력하세요"
+              className="w-full h-[67px] text-[16px] pl-14 border border-[#7E7E7E] rounded-[10px] focus:outline-none"
+            />
+          </div>
 
-        <input
-          type="password"
-          placeholder="Enter your password"
-          className="w-full px-3 py-2 mb-4 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-800"
-        />
+          <div className="relative w-[500px]">
+            <FontAwesomeIcon
+              icon={faKey}
+              className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500 p-2.5"
+            />
+            <input
+              type="password"
+              value={password}
+              onChange={handlePasswordChange}
+              placeholder="비밀번호를 입력하세요"
+              className="w-full h-[67px] text-[16px] pl-14 border border-[#7E7E7E] rounded-[10px] focus:outline-none"
+            />
+          </div>
 
-        <button className="w-full bg-blue-800 text-white py-2 rounded-lg transition duration-200">
-          로그인
-        </button>
+          {errorMessage && (
+            <div className="flex items-center gap-2 text-[#FF0000] text-[16px] font-medium">
+              <FontAwesomeIcon icon={faCircleExclamation} />
+              <span>{errorMessage}</span>
+            </div>
+          )}
+
+          <button
+            onClick={handleLogin}
+            className="flex items-center justify-center gap-2 w-[500px] h-[50px] text-white py-2 rounded-[10px] transition duration-200"
+            style={{ backgroundColor: "#3D489E" }}
+          >
+            로그인
+          </button>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
# [Style] 로그인 UI 수정 (#24 )    

## 🔗 관련 이슈
Closes #24      // 

## 📝 변경 사항
- 전체적인 디자인 수정
- 아이디, 비밀번호 입력하는 칸에 아이콘 삽입
- 로그인 버튼 누르면 홈 화면으로 돌아가게 설정
- 로그인 실패 시 에러메세지 출력

## 📷 스크린샷/GIF
<img width="1573" height="777" alt="image" src="https://github.com/user-attachments/assets/3f36e5be-bc85-4f5f-a328-cb9a01bb2665" />
<img width="1635" height="880" alt="image" src="https://github.com/user-attachments/assets/fa494de1-c9ab-4f42-b235-aac0c4159722" />

## 리뷰 시 주의사항
npm i --save @fortawesome/fontawesome-svg-core
npm i @fortawesome/free-solid-svg-icons @fortawesome/free-regular-svg-icons @fortawesome/free-brands-svg-icons
npm i --save @fortawesome/react-fontawesome@latest
터미널에 입력해야 아이콘이 보여요